### PR TITLE
Tourmodel

### DIFF
--- a/app/models/tour.rb
+++ b/app/models/tour.rb
@@ -1,7 +1,7 @@
 class Tour < ApplicationRecord
 
-    has_many :tours, dependent: :destroy
-    has_many :tour_activities
+    has_many :tours
+    has_many :tour_activities, dependent: :destroy
     belongs_to :tour, optional: true
     belongs_to :user
 

--- a/app/models/tour.rb
+++ b/app/models/tour.rb
@@ -13,7 +13,17 @@ class Tour < ApplicationRecord
     new_tour = self.dup
     new_tour.user = user
     new_tour.tour = self
-    # self.tour = new_tour
-    new_tour.save
- end
+    new_tour.save!
+    cloned_tour_activities(new_tour)
+    new_tour
+  end
+
+  private
+
+  def cloned_tour_activities(tour)
+    self.tour_activities.each do |tour_activity|
+      cloned_tour_activity = tour_activity.clone
+      cloned_tour_activity.update(tour_id: tour.id)
+    end
+  end
 end

--- a/app/models/tour_activity.rb
+++ b/app/models/tour_activity.rb
@@ -2,4 +2,11 @@ class TourActivity < ApplicationRecord
     belongs_to :tour
     belongs_to :activity
 
+
+  def clone
+    new_tour_activity = self.dup
+    new_tour_activity.save!
+    new_tour_activity
+  end
+
 end

--- a/app/models/tour_activity.rb
+++ b/app/models/tour_activity.rb
@@ -2,11 +2,9 @@ class TourActivity < ApplicationRecord
     belongs_to :tour
     belongs_to :activity
 
-
   def clone
     new_tour_activity = self.dup
     new_tour_activity.save!
     new_tour_activity
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,5 +3,5 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  has_many :tours
+  has_many :tours, dependent: :destroy
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
- 
+
   get 'tour_activity/edit'
 
   devise_for :users
@@ -10,6 +10,14 @@ Rails.application.routes.draw do
       patch :publish
     end
   end
+
+  resources :tours do
+    resources :activities do
+    end
+  end
+
+
+
   resources :activities, only: [:new, :create, :edit]
   resources :locations, only: [:new, :create, :edit, :update, :show]
 
@@ -19,4 +27,3 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end
 
- 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
 
-  get 'tour_activity/edit'
+  # get 'tour_activity/edit'
 
   devise_for :users
   root to: 'pages#home'
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
 
   get '/dashboard', to: 'pages#dashboard'
 
-  resources :users, only: [:index, :show, :edit, :update]
+  # resources :users, only: [:index, :show, :edit, :update]
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,13 +12,12 @@ Rails.application.routes.draw do
   end
 
   resources :tours do
-    resources :activities do
+    resources :activities, only: [ :new, :create, :edit, :update ] do
     end
   end
 
+  resources :tour_activities, only: [ :new, :create, :edit, :update ]
 
-
-  resources :activities, only: [:new, :create, :edit]
   resources :locations, only: [:new, :create, :edit, :update, :show]
 
   get '/dashboard', to: 'pages#dashboard'

--- a/db/migrate/20210227013424_add_hidden_to_tour_activities.rb
+++ b/db/migrate/20210227013424_add_hidden_to_tour_activities.rb
@@ -1,0 +1,5 @@
+class AddHiddenToTourActivities < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tour_activities, :hidden, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_25_092215) do
-
+ActiveRecord::Schema.define(version: 2021_02_27_013424) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,6 +50,7 @@ ActiveRecord::Schema.define(version: 2021_02_25_092215) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "tour_id", null: false
     t.bigint "activity_id", null: false
+    t.boolean "hidden", default: false
     t.index ["activity_id"], name: "index_tour_activities_on_activity_id"
     t.index ["tour_id"], name: "index_tour_activities_on_tour_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -99,7 +99,7 @@ end
     )
 
   # puts "creating 1 tour activity"
- 
+
   TourActivity.create!(
     tour: Tour.last,
     activity: Activity.last,


### PR DESCRIPTION
adjusted a dependent destroy connection to not delete child tours when deleting parent tours. Also to delete tour_activities when deleting tours. 